### PR TITLE
Fix "unexpected end of JSON input" and "max event listeners exceeded" errors

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -19,8 +19,8 @@ const getBlockHashByHeight = (height) => {
   return client([blockchain.getBlockHash, height])
 }
 
-const getRawTransaction = (txHash) => {
-  return client([blockchain.getRawTransaction, txHash])
+const getRawTransaction = (txHash, verbose = true) => {
+  return client([blockchain.getRawTransaction, txHash, verbose])
 }
 
 module.exports = {

--- a/main.js
+++ b/main.js
@@ -9,14 +9,9 @@ const client = (args) => {
     process.exit(1)
   }
 
-  process.on('unhandledRejection', (err) => {
-    console.error(`Unhandled rejection error: ${err}`)
-    process.exit(1)
-  })
-
-  process.setMaxListeners(20)
-
   return new Promise( (resolve, reject) => {
+    let result = ''
+    let resultError = ''
     let worker = spawn(`${blockchainCli} ${args.join(' ')}`, {
       shell: true
     })
@@ -34,6 +29,9 @@ const client = (args) => {
     worker.on('close', (reason) => {
       if (reason !== 0) {
         console.warn(`closed for reason: ${reason}`)
+        reject(resultError)
+      } else {
+        resolve(result)
       }
     })
 
@@ -42,11 +40,11 @@ const client = (args) => {
     })
 
     worker.stdout.on('data', (data) => {
-      resolve(data.toString())
+      result += data.toString()
     })
 
     worker.stderr.on('data', (data) => {
-      reject(data.toString())
+      resultError += data.toString()
     })
   })
 }

--- a/scraper.js
+++ b/scraper.js
@@ -12,7 +12,7 @@ const scraper = async (blockheight) => {
 
     for (let i = 0; i < transactions.length; i++) {
       let rawTx = await api.getRawTransaction(transactions[i])
-      console.log(await (api.decodeRawTransaction(rawTx)))
+      console.log(rawTx)
     }
 
   } catch (err) {


### PR DESCRIPTION
- separate stderr and stdout results for promise resolution
- getRawTransaction defaults to verbose (JSON formatted string) output
- only resolve/reject promises on stream close
- remove as yet unneeded (and massively duplicated) unhandledRejection event listener being created with every api call