### PR TITLE
Tidy up and update readme

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -30,7 +30,6 @@ const getInfo = () => {
 
 const getRawTransaction = async (txHash, verbose = true) => {
   const result = await client([blockchain.getRawTransaction, txHash, verbose])
-  cache(['set', txHash, JSON.parse(result).vout])
   return result
 }
 

--- a/api/api.js
+++ b/api/api.js
@@ -3,6 +3,11 @@ const litecoin = require('./litecoin-api')
 
 let blockchain = undefined
 
+if (blockchainCli === undefined) {
+  console.error('BLOCKCHAINCLI undefined! Enviroment variable required. Read the docs!')
+  process.exit(1)
+}
+
 if (blockchainCli.endsWith('litecoin-cli') || blockchainCli.endsWith('bitcoin-cli')) {
   blockchain = litecoin
 }

--- a/client.js
+++ b/client.js
@@ -33,11 +33,6 @@ const cache = (args) => {
 }
 
 const client = (args) => {
-  if (blockchainCli === undefined) {
-    console.error('BLOCKCHAINCLI undefined! Enviroment variable required. Read the docs!')
-    process.exit(1)
-  }
-
   return new Promise( (resolve, reject) => {
     let result = ''
     let resultError = ''

--- a/client.js
+++ b/client.js
@@ -1,7 +1,7 @@
 const { spawn } = require('child_process')
 const { LRUMap } = require('lru_map')
 
-const blockchainCli = process.env.BLOCKSCRAPECLI || 'litecoin-cli'
+const blockchainCli = process.env.BLOCKSCRAPECLI
 
 let lruCache = new LRUMap(5000)
 
@@ -33,6 +33,11 @@ const cache = (args) => {
 }
 
 const client = (args) => {
+  if (blockchainCli === undefined) {
+    console.error('BLOCKCHAINCLI undefined! Enviroment variable required. Read the docs!')
+    process.exit(1)
+  }
+
   return new Promise( (resolve, reject) => {
     let result = ''
     let resultError = ''

--- a/main.js
+++ b/main.js
@@ -10,8 +10,8 @@ const cores = os.cpus()
 const lastWrittenBlockFile = `${path.resolve(__dirname)}/last-written-block`
 const csvFile = `${path.resolve(__dirname)}/exportedData.csv`
 
-const blockEnd = process.env.BLOCKSCRAPEEND || 0
-let blockBegin = process.env.BLOCKSCRAPEBEGIN
+let blockBegin = process.env.BLOCKSCRAPEFROM
+let blockEnd = process.env.BLOCKSCRAPETO || 1349900
 
 let blocksToWrite = []
 let firstBlock = true
@@ -123,6 +123,10 @@ const main = () => {
   if (cluster.isMaster) {
     if (blockBegin === undefined) {
       blockBegin = (lastWrittenBlockFromFile() - 1)
+    }
+
+    if (blockBegin < blockEnd) {
+      blockBegin = blockEnd + (blockEnd = blockBegin, 0)
     }
 
     blockHeight = blockBegin

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "Scrape blockchains for desired attributes and export to a CSV file",
   "main": "main.js",
+  "bin": {
+    "blockscrape": "./main.js"
+  },
   "dependencies": {
     "eslint": "^4.19.0",
     "lru_map": "^0.3.3"

--- a/scraper.js
+++ b/scraper.js
@@ -14,8 +14,9 @@ const scraper = async (blockHeight) => {
 
     let txAmount = globals.getTransactionTotal(tx.vout)
     let fee = await globals.calculateFee(tx, txAmount)
+    let txTime = new Date(tx.time * 1000)
 
-    blockTransactionData.push([blockHeight, txAmount, fee, tx.time, tx.txid])
+    blockTransactionData.push([blockHeight, txAmount, fee, txTime, tx.txid])
   }
 
   console.log(`Block ${blockHeight} done after processing ${transactions.length - 1} transactions!`)


### PR DESCRIPTION
- automatically switch blockStart and blockEnd variables if blockStart is lower to ensure scraping goes in reverse (and to not fail is user puts in opposite order)
- read me is now actually a read me
- added binary option so users can `npm link` > `blockscrape` from their terminal
- put restartBlockscrape.sh script example inside readme
- BLOCKSCRAPECLI no longer defaults to litecoin (must be set in env)