### PR TITLE
Add kill switch and smarter data dump save feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,8 @@ typings/
 *.csv
 *.heapsnapshot
 
+# ignore restart blockscrape script
+restartBlockscrape.sh
+
 # local debug file
 debug.js

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ blockscrape will begin at the highest block and end at the lowest.
 The scraper does have some persistance although it's pretty basic: blockscrape saves the last written block to a file (`last-written-block`) and will begin from the next block down the chain, so you can safely restart it with, say, a
 cron job in case it dies.
 
-The data dumps are saved in the (you guessed it!) dumps folder which
+The data dumps are saved in the (you guessed it!) dumps folder and reference the first and final (last written) blocks
+in the data dump, for example `blocks-109330-109300.csv`.
 
 * BLOCKSCRAPECACHESIZE: max transactions able to be stored in the LRU cache (defaults to `100000`)
 * BLOCKSCRAPECLI: the name of the cli interface of your local blockchain, in undefined defaults to `bitcoin-cli`

--- a/client.js
+++ b/client.js
@@ -1,7 +1,7 @@
 const { spawn } = require('child_process')
 const { LRUMap } = require('lru_map')
 
-const blockchainCli = process.env.BLOCKSCRAPECLI || 'bitcoin-cli'
+const blockchainCli = process.env.BLOCKSCRAPECLI || 'litecoin-cli'
 const cacheSize = process.env.BLOCKSCRAPECACHESIZE || 100000
 
 let txVoutCache = new LRUMap(cacheSize)


### PR DESCRIPTION
- add kill switch ability by allowing user to specify BLOCKSCRAPELIMIT
- program exits gracefully due to write stream being closed by last worker and exported data moved to dumps folder
- save data dumps inside dump folder using `blocks-firstBlock-lastWrittenBlock.csv` format
- new save feature means exportedData.csv is a temporary file/write stream, meaning program avoids opening and writing to existing data dump files which are potentially millions of lines long (with no block limit set data dumps still don't have an upper limit, need to assess how this impacts performance)