### PR TITLE
Cache all transactions

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -2,17 +2,17 @@ const { client, blockchainCli, blockchainApi, blockchainApiToken } = require('..
 const litecoin = require('./litecoin.js')
 const blockcypher = require('./blockcypher.js')
 
-let api = undefined
+let blockchain = undefined
 let args = { method: 'GET', port: 443, strictSSL: true }
 let defaultParams = []
 
 if (blockchainCli.endsWith('litecoin-cli') || blockchainCli.endsWith('bitcoin-cli')) {
-  api = litecoin
+  blockchain = litecoin
 }
 
 // if both api (remote) and cli (local) are defined remote endpoint is given preference
 if (blockchainApi && blockchainApi.includes('blockcypher')) {
-  api = blockcypher
+  blockchain = blockcypher
   // NOTE blockcypher refuses to return data, waiting on response from their team,
   // see: https://github.com/blockcypher/node-client/issues/25
   if (blockchainApiToken) {
@@ -43,40 +43,40 @@ function setDefaults(params) {
 }
 
 const decodeRawTransaction = (txHash, params) => {
-  if (api === blockcypher) {
+  if (blockchain === blockcypher) {
     args.method = 'POST' // NOTE figure out design pattern to move all conditionals outside of these core api functions
   }
 
   params = setDefaults(params)
-  return client([api.decodeRawTransaction, txHash], params, args)
+  return client([blockchain.decodeRawTransaction, txHash], params, args)
 }
 
 const getBlockByHash = (blockhash, params) => {
   params = setDefaults(params)
-  return client([api.getBlockByHash, blockhash], params, args)
+  return client([blockchain.getBlockByHash, blockhash], params, args)
 }
 
 const getBlockByHeight = (height, params) => {
   params = setDefaults(params)
-  return client([api.getBlockByHeight, height], params, args)
+  return client([blockchain.getBlockByHeight, height], params, args)
 }
 
 const getBlockHashByHeight = (height, params) => {
   params = setDefaults(params)
-  return client([api.getBlockHash, height], params, args)
+  return client([blockchain.getBlockHash, height], params, args)
 }
 
 const getInfo = (params) => {
   params = setDefaults(params)
-  return client([api.getInfo], params, args)
+  return client([blockchain.getInfo], params, args)
 }
 
 const getRawTransaction = (txHash, params) => {
-  if (api === litecoin && typeof(params) === 'undefined') {
+  if (blockchain === litecoin && typeof(params) === 'undefined') {
     params = [true] // see above note
   }
   params = setDefaults(params)
-  return client([api.getRawTransaction, txHash], params, args)
+  return client([blockchain.getRawTransaction, txHash], params, args)
 }
 
 module.exports = {

--- a/api/api.js
+++ b/api/api.js
@@ -71,12 +71,12 @@ const getInfo = (params) => {
   return client([blockchain.getInfo], params, args)
 }
 
-const getRawTransaction = (txHash, params) => {
+const getTransactionByHash = (txHash, params) => {
   if (blockchain === litecoin && typeof(params) === 'undefined') {
     params = [true] // see above note
   }
   params = setDefaults(params)
-  return client([blockchain.getRawTransaction, txHash], params, args)
+  return client([blockchain.getTransactionByHash, txHash], params, args)
 }
 
 module.exports = {
@@ -85,5 +85,5 @@ module.exports = {
   getBlockByHeight,
   getBlockHashByHeight,
   getInfo,
-  getRawTransaction
+  getTransactionByHash
 }

--- a/api/blockcypher.js
+++ b/api/blockcypher.js
@@ -4,5 +4,5 @@ module.exports = {
   getBlockByHash: '/blocks',
   getBlockByHeight: '/blocks',
   getInfo: '/',
-  getRawTransaction: '/txs'
+  getTransactionByHash: '/txs'
 }

--- a/api/litecoin.js
+++ b/api/litecoin.js
@@ -51,7 +51,7 @@ module.exports = {
   getPeerInfo: 'getpeerinfo',
   getRawChangeAddress: 'getrawchangeaddress',
   getRawMempool: 'getrawmempool',
-  getRawTransaction: 'getrawtransaction',
+  getTransactionByHash: 'getrawtransaction',
   getReceivedByAccount: 'getreceivedbyaccount',
   getReceivedByAddress: 'getreceivedbyaddress',
   getTransaction: 'gettransaction',

--- a/helpers.js
+++ b/helpers.js
@@ -12,7 +12,7 @@ const getTransactionOutputs = async (txHash) => {
     const rawTx = await api.getRawTransaction(txHash)
     let tx = parser.txParser(rawTx)
     outputs = tx.outputs
-    cache(['set', txHash, tx.outputs])
+    cache(['set', txHash, outputs])
   }
 
   return outputs

--- a/helpers.js
+++ b/helpers.js
@@ -1,26 +1,30 @@
 const api = require('./api/api.js')
 const { cache } = require('./client.js')
-const parser = require('./parser.js')
+const { parseTransaction } = require('./parser.js')
 
-// attempt to get a cached copy of a transaction's output array, otherwise use getRawTransaction to fetch it
-const getTransactionOutputs = async (txHash) => {
-  let outputs = undefined
+// attempt to get a cached copy of a transaction, if this fails, parse and store the result of hitting the api
+const getCachedTransaction = async (txHash) => {
+  let transaction = undefined
 
   if (await cache(['exists', txHash])) {
-    outputs = await cache(['get', txHash])
+    transaction = await cache(['get', txHash])
   } else {
-    const rawTx = await api.getRawTransaction(txHash)
-    let tx = parser.txParser(rawTx)
-    outputs = tx.outputs
-    cache(['set', txHash, outputs])
+    transaction = await api.getTransactionByHash(txHash)
+    transaction = parseTransaction(transaction)
+    cache(['set', txHash, transaction])
   }
 
-  return outputs
+  return transaction
 }
+
+// the calling context of getCachedTransction defines its cache so we must wrap it into an exposed method which has
+// the 'helper' file as it's calling scope to prevent spwaning multiple caches which are not shared
+const getTransaction = async (txHash) => getCachedTransaction(txHash)
 
 // loop through the outputs of a transaction, greedily returning the value of the output whos index matches inputIndex
 const getMatchingTransactionValue = async (txHash, inputIndex) => {
-  let outputs = await getTransactionOutputs(txHash)
+  const transaction = await getCachedTransaction(txHash)
+  let outputs = transaction.outputs
 
   for (let i = 0; i < outputs.length; i++) {
     if (outputs[i].index === inputIndex) {
@@ -45,5 +49,6 @@ const calculateFee = async (tx, outputTotal) => {
 
 module.exports = {
   calculateFee,
+  getTransaction,
   getTransactionTotal
 }

--- a/parser.js
+++ b/parser.js
@@ -76,7 +76,7 @@ const populateOutputs = (transaction, outputs) => {
 }
 
 // scannerless transaction parser which checks tx attributes against matching string tokens (does not transform data)
-const txParser = (rawTx) => {
+const parseTransaction = (rawTx) => {
   if (typeof(rawTx) === 'string') {
     rawTx = JSON.parse(rawTx)
   }
@@ -126,7 +126,7 @@ const txParser = (rawTx) => {
 }
 
 // scannerless block parser which checks block attributes against matching string tokens (does not transform data)
-const blockParser = (rawBlock) => {
+const parseBlock = (rawBlock) => {
   if (typeof(rawBlock) === 'string') {
     rawBlock = JSON.parse(rawBlock)
   }
@@ -193,7 +193,7 @@ const transformData = (object, convertToISO = true, convertToSatoshis = true) =>
 }
 
 module.exports = {
-  blockParser,
-  txParser,
+  parseBlock,
+  parseTransaction,
   transformData
 }

--- a/scraper.js
+++ b/scraper.js
@@ -1,22 +1,22 @@
 const api = require('./api/api.js')
 const helpers = require('./helpers.js')
-const parser = require('./parser.js')
+const { parseTransaction, parseBlock, transformData } = require('./parser.js')
 
 const scraper = async (blockHeight) => {
   let blockHash = await api.getBlockHashByHeight(blockHeight)
   let rawBlock = await api.getBlockByHash(blockHash)
-  let block = parser.blockParser(rawBlock)
+  let block = parseBlock(rawBlock)
   let blockTransactionData = []
 
   // skip the generation transaction (coinbase) when scraping
   for (let i = 1; i < block.transactions.length; i++) {
-    let rawTx = await api.getRawTransaction(block.transactions[i])
-    let tx = parser.txParser(rawTx)
+    let rawTx = await api.getTransactionByHash(block.transactions[i])
+    let tx = parseTransaction(rawTx)
 
     tx.total = tx.total || helpers.getTransactionTotal(tx.outputs)
     tx.fee = tx.fee || await helpers.calculateFee(tx, tx.total)
 
-    tx = parser.transformData(tx)
+    tx = transformData(tx)
 
     blockTransactionData.push([blockHeight, tx.total, tx.fee, tx.timeReceived, tx.hash])
   }

--- a/scraper.js
+++ b/scraper.js
@@ -1,6 +1,6 @@
 const api = require('./api/api.js')
 const helpers = require('./helpers.js')
-const { parseTransaction, parseBlock, transformData } = require('./parser.js')
+const { parseBlock, transformData } = require('./parser.js')
 
 const scraper = async (blockHeight) => {
   let blockHash = await api.getBlockHashByHeight(blockHeight)
@@ -10,8 +10,7 @@ const scraper = async (blockHeight) => {
 
   // skip the generation transaction (coinbase) when scraping
   for (let i = 1; i < block.transactions.length; i++) {
-    let rawTx = await api.getTransactionByHash(block.transactions[i])
-    let tx = parseTransaction(rawTx)
+    let tx = await helpers.getTransaction(block.transactions[i])
 
     tx.total = tx.total || helpers.getTransactionTotal(tx.outputs)
     tx.fee = tx.fee || await helpers.calculateFee(tx, tx.total)


### PR DESCRIPTION
May as well cache all transactions since, while traversing the chain backwards, we are guaranteed that the current transaction will exist inside the outputs of an older transaction.